### PR TITLE
Added more descriptive logging for /say

### DIFF
--- a/index.js
+++ b/index.js
@@ -2009,14 +2009,12 @@ client.on("interactionCreate", async function (interaction) {
         content: "<:successful:1043300109921829054> Done!",
         ephemeral: true,
       });
-      interaction.channel.send({
+      const message = interaction.channel.send({
         content: interaction.options.getString("content"),
       });
       var logs = await client.channels.fetch(scatt.channels.logs);
       logs.send({
-        content: `<@${
-          interaction.user.id
-        }> used me to say: ${interaction.options.getString("content")}`,
+        content: `<@${interaction.user.id}> used me to say, "${interaction.options.getString("content")}" in <#${interaction.channel.id}>\n${message.url}`,
         allowedMentions: { users: [] },
       });
     }


### PR DESCRIPTION
When an admin uses /say, it uses a more descriptive format of logging in the logs channel:- {user} user me say, "{message}" in {channel}
{message link}