### PR TITLE
Fixed Nickname logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -2460,9 +2460,8 @@ client.on("guildMemberUpdate", async (before, after) => {
     before.nickname !== after.nickname &&
     !before.roles.cache.some((role) => role.name === "Moderator")
   ) {
-    if (after.nickname) {
       scatt.log({
-        content: `<@${after.user.id}> changed their nickname from ${before.nickname} to ${after.nickname}.`,
+        content: `<@${after.user.id}> changed their nickname from "${before.nickname || before.username}" to "${after.nickname}".`,
       });
       var members = await before.guild.members.fetch();
       var taken = false;

--- a/index.js
+++ b/index.js
@@ -2461,7 +2461,7 @@ client.on("guildMemberUpdate", async (before, after) => {
     !before.roles.cache.some((role) => role.name === "Moderator")
   ) {
       scatt.log({
-        content: `<@${after.user.id}> changed their nickname from "${before.nickname || before.username}" to "${after.nickname}".`,
+        content: `<@${after.user.id}> changed their nickname from "${before.nickname || before.username}" to "${after.nickname || after.username}".`,
       });
       var members = await before.guild.members.fetch();
       var taken = false;


### PR DESCRIPTION
When a user changes their nickname from default to a new nickname it says "@User changed their nickname from null to User". also if a user uses spaces in their name, it gets confusing to read. One last thing, it doesnt log if the user clears their username